### PR TITLE
Update bus button default to start enabled

### DIFF
--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -28,7 +28,7 @@ const store: StoreOptions<StoreState> = {
     adminMessage: undefined,
     online: true,
     settings: {
-      busButtonEnabled: false,
+      busButtonEnabled: true,
       etasEnabled: false,
       fusionPositionEnabled: true,
       busButtonChoice: '🚌',


### PR DESCRIPTION
I am a big fan of the bus button. However I feel it is underutilized by students as most do not know that it exists.
This pr enables the bus button by default. Therefore students still have the option to disable it, however more students will discover it and hopefully use it.

I do not really see a downside in having it on by default. The ui space it takes up is very minimal and I think many students would enjoy the bus button as much as I do (once they realize it exists)!